### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/OneTesseractInMultiverse/moleql/security/code-scanning/1](https://github.com/OneTesseractInMultiverse/moleql/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions` block to the workflow, setting it to the minimum required privileges. For a typical CI job that only reads code, the least privilege is `contents: read`. This can be done at either the top-level of the workflow (so that it applies to all jobs unless individually overridden) or directly inside the specific job definition. As there is only one job in the workflow, and no steps requiring write access, the preferred fix is to add a top-level `permissions:` block immediately after the workflow `name:` declaration in `.github/workflows/ci.yml`. No additional imports, method definitions, or changes to steps are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
